### PR TITLE
Allow developer to override tags for single transaction

### DIFF
--- a/cypress/integration/transactions.spec.js
+++ b/cypress/integration/transactions.spec.js
@@ -64,4 +64,67 @@ describe('On-Page Transactions', () => {
         .to.be.below(new Date(secondTransaction.startTime));
     });
   });
+
+  it('Tags can be overriden', () => {
+    // open the e2e.html page
+    cy.visit('/e2e.html');
+
+    // start the Cypress server to be able to stub responses
+    cy.server();
+
+    // define stubbed route for sampling
+    cy.route({
+      method: 'HEAD',
+      url: '/sampling/*',
+      status: 200,
+      response: {},
+      headers: {
+        'X-Sematext-Experience-App-Active': true,
+        'X-Sematext-Experience-Sampling-Active': false,
+        'X-Sematext-Experience-Sampling-NextEvent': true,
+        'X-Sematext-Experience-Sampling-Percentage': 100,
+      },
+    }).as('head');
+
+    // define stubbed route for sending data
+    cy.route({
+      method: 'POST',
+      url: '/api/v1/apps/8763d12d-1j3t-932v-b498-544290z98k43/data*',
+      status: 200,
+      response: {
+        error: false,
+        message: 'accepted event',
+      },
+    }).as('sendData');
+
+    // wait for initial page load to be sent
+    cy.wait('@sendData');
+
+    cy.contains('SendOnPageTransaction').click();
+    cy.wait('@sendData').then((xhr) => {
+      assert.isNotNull(xhr.request.body);
+      assert.isNotNull(xhr.request.body.body.transaction);
+
+      const transactions = xhr.request.body.body.transaction;
+      expect(transactions.length).to.equal(1);
+      expect(transactions[0].meta.user.tags.someTag).to.equal('default');
+    });
+
+    // Send second transaction with modified tag
+    cy.contains('SendOnPageTransactionWithTagOverriden').click();
+    cy.wait('@sendData').then((xhr) => {
+      assert.isNotNull(xhr.request.body);
+      assert.isNotNull(xhr.request.body.body.transaction);
+
+      const transactions = xhr.request.body.body.transaction;
+      expect(transactions.length).to.equal(1);
+
+      // check if the tag was successfully overriden
+      expect(transactions[0].meta.user.tags.someTag).to.equal('overriden');
+
+      // check that other tags remained intact
+      expect(transactions[0].meta.user.identifier).to.equal('testuser');
+      expect(transactions[0].meta.user.name).to.equal('testuser');
+    });
+  });
 });

--- a/e2e.html
+++ b/e2e.html
@@ -14,6 +14,7 @@
     <script type="text/javascript">
       window.STRUM_CONTEXTS = ['strum'];
       strum('config', { token: sematextExperienceToken, receiverUrl: sematextExperienceReceiverURL });
+      strum('identify', { identifier: 'testuser', name: 'testuser', tags: { someTag: 'default' } });
     </script>
     <script type="text/javascript">
       function moveTurtle(maxTime) {
@@ -64,6 +65,11 @@
         strum('startTransaction', 'SomeTransaction');
         setTimeout(() => strum('endTransaction', 'SomeTransaction'), 200);
       }
+      window.sendOnPageTransactionWithTagOverriden = function () {
+        // generate 200ms on-page transaction
+        strum('startTransaction', 'SomeTransaction', { someTag: 'overriden' });
+        setTimeout(() => strum('endTransaction', 'SomeTransaction'), 200);
+      }
     </script>
 </head>
 <body>
@@ -75,6 +81,7 @@
         <p><button id="sendWithLongJob" onclick="sendWithLongJob()">SendWithLongJob</button></p>
         <p><button id="addTextElement" onclick="addTextElement()">AddTextElement</button></p>
         <p><button id="onPageTrx" onclick="sendOnPageTransaction()">SendOnPageTransaction</button></p>
+        <p><button id="onPageTrx2" onclick="sendOnPageTransactionWithTagOverriden()">SendOnPageTransactionWithTagOverriden</button></p>
         <p><button id="addTextElementWithoutRoute" onclick="addTextElementWithoutRoute()">AddTextElementWithoutRoute</button></p>
     </div>
     <p elementtiming="test_div_for_element_timing_second">Second Element Timing Paragraph</p>

--- a/src/commands/transactions.js
+++ b/src/commands/transactions.js
@@ -18,9 +18,16 @@ class StartTransactionCommand implements Command {
 
     const name: string = args[0];
 
+    const tags: Object = args[1];
+
+    if (tags && typeof tags !== 'object') {
+      throw new Error('if provided, second argument `tags` should be an object');
+    }
+
     if (!transactions[name]) {
       transactions[name] = {
         startTime: new Date(),
+        tags,
       };
     }
   }
@@ -44,14 +51,14 @@ class EndTransactionCommand implements Command {
       throw new Error(`transaction "${name}" was never started`);
     }
 
-    const { startTime } = transactions[name];
+    const { startTime, tags } = transactions[name];
     const endTime = new Date();
 
     const doc = {
       name,
       startTime: startTime.toISOString(),
       endTime: endTime.toISOString(),
-      meta: getDefaultMeta(this.context),
+      meta: getDefaultMeta(this.context, tags),
     };
 
     const { uploader } = this.context;

--- a/src/commands/types.js
+++ b/src/commands/types.js
@@ -5,6 +5,7 @@ export type UserInfo = {
   name: ?string,
   identifier: string,
   anonymous: boolean,
+  tags: ?Object,
 };
 
 export type CommandContext = {

--- a/src/common.js
+++ b/src/common.js
@@ -64,10 +64,17 @@ export const getConnectionType = () => {
   return c && c.effectiveType;
 };
 
-export const getDefaultMeta = (context: CommandContext) => ({
-  user: context.user || ({
+export const getDefaultMeta = (context: CommandContext, mergeTags: ?Object) => ({
+  user: context.user ? ({
+    ...context.user,
+    tags: {
+      ...context.user.tags,
+      ...mergeTags,
+    },
+  }) : ({
     identifier: context.anonUserID,
     anonymous: true,
+    tags: mergeTags,
   }),
   sessionID: context.sessionID,
   release: context.config && context.config.release,


### PR DESCRIPTION
This PR introduces a small change to transactions to allow developer to override custom tags for each transaction event. Previously the only way to do this would be to call `identify` before / after the `startTransaction` command.