### PR TITLE
Collect performance.measure() measurements as on-page transactions

### DIFF
--- a/e2e.html
+++ b/e2e.html
@@ -65,6 +65,10 @@
         strum('startTransaction', 'SomeTransaction');
         setTimeout(() => strum('endTransaction', 'SomeTransaction'), 200);
       }
+      window.sendOnPageTransactionWithMeasure = function () {
+        // this will measure time from navigation start
+        performance.measure('WithMeasure');
+      }
       window.sendOnPageTransactionWithTagOverriden = function () {
         // generate 200ms on-page transaction
         strum('startTransaction', 'SomeTransaction', { someTag: 'overriden' });
@@ -82,6 +86,7 @@
         <p><button id="addTextElement" onclick="addTextElement()">AddTextElement</button></p>
         <p><button id="onPageTrx" onclick="sendOnPageTransaction()">SendOnPageTransaction</button></p>
         <p><button id="onPageTrx2" onclick="sendOnPageTransactionWithTagOverriden()">SendOnPageTransactionWithTagOverriden</button></p>
+        <p><button id="onPageTrx3" onclick="sendOnPageTransactionWithMeasure()">SendOnPageTransactionWithMeasure</button></p>
         <p><button id="addTextElementWithoutRoute" onclick="addTextElementWithoutRoute()">AddTextElementWithoutRoute</button></p>
     </div>
     <p elementtiming="test_div_for_element_timing_second">Second Element Timing Paragraph</p>

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -5,7 +5,7 @@ import AjaxCommand from './AjaxCommand';
 import IdentifyCommand from './IdentifyCommand';
 import RouteChangeCommand from './RouteChangeCommand';
 import VitalMetricCommand from './VitalMetricCommmand';
-import { StartTransactionCommand, EndTransactionCommand } from './transactions';
+import { RecordTransactionCommand, StartTransactionCommand, EndTransactionCommand } from './transactions';
 import type {
   CommandContext,
   Command,
@@ -20,6 +20,7 @@ const commands = {
   ajax: AjaxCommand,
   startTransaction: StartTransactionCommand,
   endTransaction: EndTransactionCommand,
+  recordTransaction: RecordTransactionCommand,
   identify: IdentifyCommand,
   routeChange: RouteChangeCommand,
   longTask: LongTaskCommand,

--- a/src/dispatchers/MeasureDispatcher.js
+++ b/src/dispatchers/MeasureDispatcher.js
@@ -1,0 +1,72 @@
+/* @flow */
+import type { Dispatcher } from './types';
+import CommandExecutor from '../CommandExecutor';
+import { logDebug } from '../common';
+
+export const measureSupported = (): boolean => {
+  if (window.PerformanceObserver && window.PerformanceObserver.supportedEntryTypes &&
+    PerformanceObserver.supportedEntryTypes.indexOf('measure') >= 0) {
+    return true;
+  }
+  return false;
+};
+
+class MeasureDispatcher implements Dispatcher {
+  executors: Array<CommandExecutor>;
+  started: boolean;
+  observer: PerformanceObserver;
+
+  constructor() {
+    this.executors = [];
+    this.started = false;
+  }
+
+  addExecutor(executor: CommandExecutor) {
+    this.executors.push(executor);
+  }
+
+  supported() {
+    return measureSupported();
+  }
+
+  start() {
+    if (!this.supported()) {
+      logDebug('performance.measure() API is not supported, skipping MeasureDispatcher');
+    }
+
+    if (!this.started) {
+      this.started = true;
+
+      try {
+        this.observer = new PerformanceObserver(this.handleObserve);
+        this.observer.observe({ entryTypes: ['measure'] });
+        logDebug('MeasureDispatcher started');
+      } catch (ex) {
+        this.started = false;
+        logDebug('Error starting MeasureDispatcher');
+      }
+    }
+  }
+
+  pause() {
+    if (this.started) {
+      this.started = false;
+      this.observer.disconnect();
+
+      logDebug('MeasureDispatcher paused');
+    }
+  }
+
+  handleObserve = (list: PerformanceObserverEntryList) => {
+    if (this.started) {
+      const entries = list.getEntries();
+      entries.forEach((entry) => {
+        const { name, startTime, duration } = entry;
+        console.log(entry);
+        this.executors.forEach(e => e.execute('recordTransaction', name, startTime, duration));
+      });
+    }
+  }
+}
+
+export default MeasureDispatcher;

--- a/src/dispatchers/MeasureDispatcher.js
+++ b/src/dispatchers/MeasureDispatcher.js
@@ -62,7 +62,6 @@ class MeasureDispatcher implements Dispatcher {
       const entries = list.getEntries();
       entries.forEach((entry) => {
         const { name, startTime, duration } = entry;
-        console.log(entry);
         this.executors.forEach(e => e.execute('recordTransaction', name, startTime, duration));
       });
     }

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import DocumentVisibilityObserver from './DocumentVisibilityObserver';
 import ElementTimingDispatcher from './dispatchers/ElementTimingDispatcher';
 import WebVitalsDispatcher from './dispatchers/WebVitalsDispatcher';
 import MemoryUsageDispatcher from './dispatchers/MemoryUsageDispatcher';
+import MeasureDispatcher from './dispatchers/MeasureDispatcher';
 
 const contextNames = window.STRUM_CONTEXTS || [GLOBAL_KEY];
 
@@ -28,10 +29,12 @@ const ajaxDispatcher = new AjaxDispatcher();
 const elementTimingDispatcher = new ElementTimingDispatcher();
 const webVitalsDispatcher = new WebVitalsDispatcher();
 const memoryUsageDispatcher = new MemoryUsageDispatcher();
+const measureDispatcher = new MeasureDispatcher();
 
 visibilityObserver.addListener(pageLoadDispatcher);
 visibilityObserver.addListener(ajaxDispatcher);
 visibilityObserver.addListener(elementTimingDispatcher);
+visibilityObserver.addListener(measureDispatcher);
 // DON'T: visibilityObserver.addListener(webVitalsDispatcher);
 // we're not adding web vitals dispatcher to the visibility observer because we
 // don't control the implementation of how metric are collected and I believe
@@ -54,6 +57,7 @@ contextNames.forEach((contextName) => {
     elementTimingDispatcher.addExecutor(executor);
     webVitalsDispatcher.addExecutor(executor);
     memoryUsageDispatcher.addExecutor(executor);
+    measureDispatcher.addExecutor(executor);
   });
 });
 
@@ -63,6 +67,7 @@ ajaxDispatcher.start();
 elementTimingDispatcher.start();
 webVitalsDispatcher.start();
 memoryUsageDispatcher.start();
+measureDispatcher.start();
 
 // start observing visibility changes
 visibilityObserver.startListening();


### PR DESCRIPTION
This PR adds another way to collect On-Page transactions using the performance.measure() API.

This API might already be used on websites and in those cases user will not have to wrap those parts of the code with our custom `startTransactions` and `endTransactions` commands, they can use the native browser performance.measure() API.