### PR TITLE
Allow defining AJAX sites URLs exclusion

### DIFF
--- a/src/ajax/common.js
+++ b/src/ajax/common.js
@@ -23,7 +23,7 @@ export function checkTaint(url: string, taint: string): boolean {
 
 export function isUrlIgnored(url: string, ignoreList: string[]): boolean {
   for (let i = 0; i < ignoreList.length; i += 1) {
-    if (url.startsWith(ignoreList[i])) {
+    if (url.toLowerCase().startsWith(ignoreList[i].toLowerCase())) {
       return true;
     }
   }

--- a/src/ajax/common.js
+++ b/src/ajax/common.js
@@ -20,3 +20,12 @@ export function checkTaint(url: string, taint: string): boolean {
 
   return false;
 }
+
+export function isUrlIgnored(url: string, ignoreList: string[]): boolean {
+  for (let i = 0; i < ignoreList.length; i += 1) {
+    if (url.startsWith(ignoreList[i])) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/constants.js
+++ b/src/constants.js
@@ -18,6 +18,3 @@ export const PAGELOAD_HARD_TIMEOUT = 5000;
 export const PAGELOAD_SOFT_TIMEOUT = 5000;
 
 export const BOT_USER_AGENT = RegExp('alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|google web preview|nagios|postrank|pingdom|slurp|spider|yahoo!|yandex');
-
-// the list hosts to ignore
-export const IGNORE_AJAX_KEY = 'strumignore';

--- a/src/constants.js
+++ b/src/constants.js
@@ -19,3 +19,5 @@ export const PAGELOAD_SOFT_TIMEOUT = 5000;
 
 export const BOT_USER_AGENT = RegExp('alexa|bot|crawl(er|ing)|facebookexternalhit|feedburner|google web preview|nagios|postrank|pingdom|slurp|spider|yahoo!|yandex');
 
+// the list hosts to ignore
+export const IGNORE_AJAX_KEY = 'strumignore';

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import PageLoadDispatcher from './dispatchers/PageLoadDispatcher';
 import RumUploader from './RumUploader';
 import bootstrap from './bootstrap';
 import AjaxDispatcher from './dispatchers/AjaxDispatcher';
-import { GLOBAL_KEY } from './constants';
+import { GLOBAL_KEY, IGNORE_AJAX_KEY } from './constants';
 import { setupContext, keepSessionAlive } from './common';
 import patchXhr from './ajax/xhr';
 import patchFetch from './ajax/fetch';
@@ -19,9 +19,13 @@ import MemoryUsageDispatcher from './dispatchers/MemoryUsageDispatcher';
 import MeasureDispatcher from './dispatchers/MeasureDispatcher';
 
 const contextNames = window.STRUM_CONTEXTS || [GLOBAL_KEY];
+let ignoreList = [IGNORE_AJAX_KEY];
+if (ignoreList === null) {
+  ignoreList = [];
+}
 
-patchXhr(window);
-patchFetch(window);
+patchXhr(window, ignoreList);
+patchFetch(window, ignoreList);
 
 const visibilityObserver = new DocumentVisibilityObserver();
 const pageLoadDispatcher = new PageLoadDispatcher();

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ import PageLoadDispatcher from './dispatchers/PageLoadDispatcher';
 import RumUploader from './RumUploader';
 import bootstrap from './bootstrap';
 import AjaxDispatcher from './dispatchers/AjaxDispatcher';
-import { GLOBAL_KEY, IGNORE_AJAX_KEY } from './constants';
+import { GLOBAL_KEY } from './constants';
 import { setupContext, keepSessionAlive } from './common';
 import patchXhr from './ajax/xhr';
 import patchFetch from './ajax/fetch';
@@ -19,7 +19,7 @@ import MemoryUsageDispatcher from './dispatchers/MemoryUsageDispatcher';
 import MeasureDispatcher from './dispatchers/MeasureDispatcher';
 
 const contextNames = window.STRUM_CONTEXTS || [GLOBAL_KEY];
-let ignoreList = [IGNORE_AJAX_KEY];
+let ignoreList = window.STRUM_IGNORE_AJAX;
 if (ignoreList === null) {
   ignoreList = [];
 }


### PR DESCRIPTION
This PR introduces the possibility of adding a global `window.STRUM_IGNORE_AJAX` key that defines list of URLs that should be ignored by our HTTP request intercept method. It should be added before initializing the Experience script, so as the first thing to the page, for example:

```
<script type="text/javascript">
  window.STRUM_IGNORE_AJAX = ["https://sematext.com"];
</script>
```

It will result in all AJAX requests to that domain to be ignored. 