### PR TITLE
Improve node collection

### DIFF
--- a/src/commands/RouteChangeObserver.js
+++ b/src/commands/RouteChangeObserver.js
@@ -74,6 +74,7 @@ class RouteChangeObserver {
     this.startedOffset = this.startedAt - navigationStart;
     this.context = context;
 
+    this.searchForInterestingNodesOnLoad();
     this.setupDomObserver();
     this.setupAjaxObserver();
     this.setupIdlingObserver();
@@ -200,6 +201,13 @@ class RouteChangeObserver {
       }
     });
   };
+
+  searchForInterestingNodesOnLoad() {
+    const nodes = document.querySelectorAll('img, iframe, link');
+    nodes.forEach((node) => {
+      this.waitForNode(node);
+    });
+  }
 
   /**
    * Some nodes such as img, iframe, and link can cause additional resources to

--- a/src/commands/RouteChangeObserver.js
+++ b/src/commands/RouteChangeObserver.js
@@ -181,7 +181,7 @@ class RouteChangeObserver {
   mutation = (mutations: Array<MutationRecord>) => {
     mutations.forEach((mutation) => {
       if (mutation.type === 'attributes') {
-        this.waitForNode(mutation.target);
+        this.interesting = this.waitForNode(mutation.target) || this.interesting;
       } else if (mutation.type === 'childList') {
         let len = mutation.addedNodes.length;
         let i = 0;
@@ -205,7 +205,7 @@ class RouteChangeObserver {
   searchForInterestingNodesOnLoad() {
     const nodes = document.querySelectorAll('img, iframe, link');
     nodes.forEach((node) => {
-      this.waitForNode(node);
+      this.interesting = this.waitForNode(node) || this.interesting;
     });
   }
 

--- a/src/common.js
+++ b/src/common.js
@@ -253,7 +253,7 @@ export const getCompressedResources = (
   // filter out resource types that we don't want to collect
   resources.entries = resources.entries.filter(e =>
     !e.name.startsWith('data:') && disabledResourceTypes.indexOf(e.initiatorType) === -1
-    && !e.name.includes('rum-receiver'));
+    && !e.name.includes('rum-receiver.sematext.com'));
 
   // attach resource type
   resources.entries = resources.entries.map(r => ({

--- a/src/common.js
+++ b/src/common.js
@@ -252,7 +252,8 @@ export const getCompressedResources = (
   // see https://sematext.atlassian.net/browse/SC-6210
   // filter out resource types that we don't want to collect
   resources.entries = resources.entries.filter(e =>
-    !e.name.startsWith('data:') && disabledResourceTypes.indexOf(e.initiatorType) === -1);
+    !e.name.startsWith('data:') && disabledResourceTypes.indexOf(e.initiatorType) === -1
+    && !e.name.includes('rum-receiver'));
 
   // attach resource type
   resources.entries = resources.entries.map(r => ({


### PR DESCRIPTION
In this PR we improve experience's script node collection. Currently we used mutation observer to monitor any node changes. But this means that changes are only monitored after the initial route effect has happened. This can miss stuff and I clearly saw it missing stuff in my lighter example site which was only loading a few images quickly. 
So I added the an init node checker so that we can firstly guarantee that page load is tracked and secondly make sure those nodes are consistently tracked.

I am also now filtering our own ajax calls to rum-receiver from the resources loaded. As we don't need to that as a resource to user similarly we don't show 'data:' calls.

As far as the main bug report is concerned. In my testing I found that this happens mostly on the first load. Even in my example app I was witnessing missed resources on the first load. This is because it takes experience app to load on page refresh and by then bunch of resources have been fetched. At which point we call 'routeChange' event. But this route change event can't see all the resources that were fetched before it before it was fired. Hence we miss those. So the solution will be on the app side where we will communicate with users that don't fire this event on first load.